### PR TITLE
fix: Removed compression header

### DIFF
--- a/src/GrpcFileTransfer/Client/FileTransferClient.cs
+++ b/src/GrpcFileTransfer/Client/FileTransferClient.cs
@@ -1,4 +1,3 @@
-﻿using System.IO.Compression;
 using Google.Protobuf;
 using Grpc.Core;
 using Grpc.Net.Client;
@@ -125,7 +124,6 @@ public class FileTransferClient
         if (headerFields != null)
             foreach (var headerField in headerFields)
                 headers.Add(headerField);
-        headers.Add("grpc-internal-encoding-request", "gzip");
 
         _logger?.LogDebug("Starting upload of {} to fileId {}", localFilepath, fileId);
 


### PR DESCRIPTION
Header message to enable client-side compression was not needed and could lead to an unkown encoding error by grpc if a header field changing the compression encoding was passed to `FileTransferClient.Upload` in `headerFields`.