### PR TITLE
Fix: Revert service name change

### DIFF
--- a/src/GrpcFileTransfer.Test/FileTransferIntegrationTests.cs
+++ b/src/GrpcFileTransfer.Test/FileTransferIntegrationTests.cs
@@ -37,7 +37,7 @@ public class FileTransferIntegrationTests : IntegrationTestBase, IDisposable
     [Fact]
     public Task ApiInformationTest()
     {
-        var _grpcClient = new InternalFileTransfer.InternalFileTransferClient(Channel);
+        var _grpcClient = new FileTransfer.FileTransferClient(Channel);
         var response = _grpcClient.GetInfo(new Google.Protobuf.WellKnownTypes.Empty());
         response.Should().NotBeNull();
         response.Name.Should().Be(FileTransferServiceTestImplementation.ServiceName);

--- a/src/GrpcFileTransfer/Client/FileTransferClient.cs
+++ b/src/GrpcFileTransfer/Client/FileTransferClient.cs
@@ -11,10 +11,10 @@ public class FileTransferClient
 {
     public FileTransferClient(GrpcChannel grpcChannel)
     {
-        _grpcClient = new InternalFileTransfer.InternalFileTransferClient(grpcChannel);
+        _grpcClient = new FileTransfer.FileTransferClient(grpcChannel);
     }
 
-    public FileTransferClient(InternalFileTransfer.InternalFileTransferClient grpcClient)
+    public FileTransferClient(FileTransfer.FileTransferClient grpcClient)
     {
         _grpcClient = grpcClient;
     }
@@ -24,7 +24,7 @@ public class FileTransferClient
         _logger = logger;
     }
 
-    public FileTransferClient(InternalFileTransfer.InternalFileTransferClient grpcClient, ILogger logger) :
+    public FileTransferClient(FileTransfer.FileTransferClient grpcClient, ILogger logger) :
         this(grpcClient)
     {
         _logger = logger;
@@ -217,6 +217,6 @@ public class FileTransferClient
         }
     }
 
-    private readonly InternalFileTransfer.InternalFileTransferClient _grpcClient;
+    private readonly FileTransfer.FileTransferClient _grpcClient;
     private readonly ILogger? _logger;
 }

--- a/src/GrpcFileTransfer/FileTransferService.proto
+++ b/src/GrpcFileTransfer/FileTransferService.proto
@@ -5,7 +5,7 @@ import "google/protobuf/empty.proto";
 
 package file_transfer;
 
-service InternalFileTransfer {
+service FileTransfer {
   rpc Upload(stream FileUploadRequest) returns(FileUploadResponse);
   rpc Download(FileDownloadRequest) returns(stream FileDownloadResponse);
   rpc GetInfo (google.protobuf.Empty) returns (ServiceInformation);

--- a/src/GrpcFileTransfer/Service/AbstractFileTransferService.cs
+++ b/src/GrpcFileTransfer/Service/AbstractFileTransferService.cs
@@ -7,7 +7,7 @@ using Enum = System.Enum;
 
 namespace Pulsar.GrpcFileTransfer.Service;
 
-public abstract class AbstractFileTransferService : InternalFileTransfer.InternalFileTransferBase
+public abstract class AbstractFileTransferService : FileTransfer.FileTransferBase
 {
     protected AbstractFileTransferService()
     {


### PR DESCRIPTION
Changing the name of the service from `FileTransfer` to `InternalFileTransfer` caused the service to be picked up as `internal_file_transfer` instead of `file_transfer`, which in turn caused `Unimplemented` exceptions when calling the service from the client.